### PR TITLE
Clojure 1.3 and Clojure 1.4 compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ classes
 /checkouts
 /.lein-deps-sum
 .DS_Store
+/target
+pom.xml.asc

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ pom.xml
 *jar
 lib
 classes
+.lein*

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,15 @@ pom.xml
 lib
 classes
 .lein*
+*~
+*#*
+/pom.xml
+*jar
+/lib
+/classes
+/native
+/.lein-plugins
+/.lein-failures
+/checkouts
+/.lein-deps-sum
+.DS_Store

--- a/project.clj
+++ b/project.clj
@@ -1,6 +1,6 @@
 (defproject clj-facebook-graph "0.4.0"
   :description "A Clojure client for the Facebook Graph API."
-  :dependencies [[org.clojure/clojure "1.4.0-beta3"]
+  :dependencies [[org.clojure/clojure "1.4.0"]
                  [org.clojure/data.json "0.1.2"  :exclude [org.clojure/clojure]]
                  [ring/ring-core "1.0.1"  :exclude [org.clojure/clojure]]
 

--- a/project.clj
+++ b/project.clj
@@ -1,11 +1,16 @@
 (defproject clj-facebook-graph "0.4.0"
   :description "A Clojure client for the Facebook Graph API."
-  :dependencies [[org.clojure/clojure "1.3.0"]
-                 [org.clojure/data.json "0.1.1"]
-                 [ring/ring-core "1.0.1"]
-                 [clj-http "0.2.6"]
-                 [clj-oauth2 "0.1.0"]]
-  :dev-dependencies [[ring/ring-devel "1.0.1"]
-                     [ring/ring-jetty-adapter "1.0.0"]
-                     [compojure "0.6.4"]]
+  :dependencies [[org.clojure/clojure "1.4.0-beta3"]
+                 [org.clojure/data.json "0.1.2"  :exclude [org.clojure/clojure]]
+                 [ring/ring-core "1.0.1"  :exclude [org.clojure/clojure]]
+
+                 [clj-http "0.3.6"]
+                 [clj-oauth2 "0.2.0"]]
+
+  :dev-dependencies [[ring/ring-devel "1.0.1"  :exclude [org.clojure/clojure]]
+                     [ring/ring-jetty-adapter "1.0.1"  :exclude [org.clojure/clojure]]
+                     [compojure "1.0.1"  :exclude [org.clojure/clojure]]]
+
+  :repositories {"jboss" "http://repository.jboss.org/nexus/content/groups/public/"}
+
   :aot [clj-facebook-graph.FacebookGraphException])

--- a/src/clj_facebook_graph/auth.clj
+++ b/src/clj_facebook_graph/auth.clj
@@ -10,7 +10,8 @@
 (def facebook-oauth2-endpoint
   {:access-query-param :access_token
    :authorization-uri "https://graph.facebook.com/oauth/authorize"
-   :access-token-uri "https://graph.facebook.com/oauth/access_token"})
+   :access-token-uri "https://graph.facebook.com/oauth/access_token"
+   :grant-type "authorization_code"})
 
 (defn get-access-token
   "Fetches the access token using clj-oauth2/client."

--- a/src/clj_facebook_graph/auth.clj
+++ b/src/clj_facebook_graph/auth.clj
@@ -48,7 +48,10 @@
       (if (and *facebook-auth* (string? url)
                (or (.startsWith url facebook-base-url)
                    (.startsWith url facebook-fql-base-url)))
-        (client (assoc req :oauth2 (oauth2-access-token)))
+        (client (do
+                  (-> req
+                      (assoc :oauth2 (oauth2-access-token))
+                      (assoc-in [:query-params :access_token] (:access-token *facebook-auth*)))))
         (client req)))))
 
 (defn with-facebook-access-token [uri]

--- a/src/clj_facebook_graph/client.clj
+++ b/src/clj_facebook_graph/client.clj
@@ -13,7 +13,8 @@
         [clj-facebook-graph.error-handling :only [wrap-facebook-exceptions]]
         [clojure.data.json :only [read-json]] 
         [clj-oauth2.client :only [wrap-oauth2]])
-  (:require [clj-http.client :as client])
+  (:require [clj-http.client :as client]
+            [ring.util.codec])
   (:refer-clojure :exclude [get]))
 
 (defn wrap-facebook-url-builder [client]
@@ -70,8 +71,9 @@
                 the-client (wrap-facebook-data-extractor client)]
             (if paging
               (if-let [url (get-in body [:paging :next])]
-                (lazy-cat extraction
-                          (the-client {:method :get :url url :extract :data :paging true}))
+                (let [query-params (-> url client/parse-url :query-string ring.util.codec/form-decode)]
+                  (lazy-cat extraction
+                            (the-client {:method :get :url url :query-params query-params :extract :data :paging true})))
                 extraction)
               extraction)))
         response))))

--- a/src/clj_facebook_graph/client.clj
+++ b/src/clj_facebook_graph/client.clj
@@ -72,7 +72,7 @@
               (if-let [url (get-in body [:paging :next])]
                 (lazy-cat extraction
                           (the-client {:method :get :url url :extract :data :paging true}))
-                [])
+                extraction)
               extraction)))
         response))))
 

--- a/src/clj_facebook_graph/client.clj
+++ b/src/clj_facebook_graph/client.clj
@@ -13,7 +13,8 @@
         [clj-facebook-graph.error-handling :only [wrap-facebook-exceptions]]
         [clojure.data.json :only [read-json]] 
         [clj-oauth2.client :only [wrap-oauth2]])
-  (:require [clj-http.client :as client]))
+  (:require [clj-http.client :as client])
+  (:refer-clojure :exclude [get]))
 
 (defn wrap-facebook-url-builder [client]
   "Offers some convenience by assemble a Facebook Graph API URL from a vector of keywords or strings.

--- a/src/clj_facebook_graph/helper.clj
+++ b/src/clj_facebook_graph/helper.clj
@@ -11,7 +11,7 @@
   (:use [clojure.data.json :only [read-json read-json-from Read-JSON-From]]
         [clojure.java.io :only [reader]]
         [clj-http.client :only [unexceptional-status?]]
-        [clj-oauth2.uri :only [make-uri]]
+        [uri.core :only [make]]
         [clojure.string :only [blank?]]
         ring.middleware.params)
   (:import
@@ -31,11 +31,11 @@
 (defn build-url [request]
   "Builds a URL string which corresponds to the information of the request."
   (let [{:keys [server-port server-name uri query-params scheme]} request]
-    (str (make-uri {:scheme (name scheme)
-                    :host server-name
-                    :port server-port
-                    :path uri
-                    :query query-params}))))
+    (str (make {:scheme (name scheme)
+                :host server-name
+                :port server-port
+                :path uri
+                :query query-params}))))
 
 (defn wrap-exceptions [client]
   "An alternative Ring-style middleware to the #'clj-http.core/wrap-exceptions. This

--- a/src/clj_facebook_graph/ring_middleware.clj
+++ b/src/clj_facebook_graph/ring_middleware.clj
@@ -57,7 +57,7 @@
    "
   [handler facebook-app-info callback-handler]
   (fn [request]
-    (let [code (get-in request [:params "code"])
+    (let [code (get-in request [:query-params "code"])
           callback-path (.getPath (java.net.URI. (:redirect-uri facebook-app-info)))]
       (if (and code (= callback-path (:uri request)))
         (let [params (:params ((wrap-keyword-params identity) request))

--- a/test/clj_facebook_graph/test/client.clj
+++ b/test/clj_facebook_graph/test/client.clj
@@ -1,0 +1,35 @@
+(ns clj-facebook-graph.test.client
+  (:use clojure.test)
+  (:require [clj-facebook-graph.client :as client]
+            [clj-http.client :as http]
+            [ring.util.codec]))
+
+(deftest wrap-facebook-data-extractor-test
+  (testing "data from this request should be returned even if no pagination links are in the response"
+    (let [data "DATA"
+          fb-response (constantly {:body {:data data}})
+          client (client/wrap-facebook-data-extractor fb-response)
+          request {:paging true :extract :data}
+          response (client request)]
+      (is (= response data))))
+
+  (testing "paging params should be mapped to :query-params"
+    (let [pagination-params {"since" "123"}
+          pagination-url (str "http://localhost?" (ring.util.codec/form-encode pagination-params))
+          data [1 2 3]
+          lazy-req-params (atom nil)
+          fb-response (fn [req] (reset! lazy-req-params req) {:body {:data data :paging {:next pagination-url}}})
+          client (client/wrap-facebook-data-extractor fb-response)
+          request {:paging true :extract :data}
+          response (dorun (take 4 (client request)))]
+      (is (= (:query-params @lazy-req-params) pagination-params)))))
+
+(deftest middleware-interaction-test
+  (testing "query params in :url are overridden by :query-params"
+    (let [query-params {"q" "1"}
+          query-string "q=12345"
+          client (-> identity
+                     http/wrap-query-params
+                     http/wrap-url)
+          response (client {:url (str "http://localhost/?" query-string) :query-params query-params})]
+      (is (= (ring.util.codec/form-decode (:query-string response)) query-params)))))


### PR DESCRIPTION
Changes
- Made it clojure 1.3 and clojure 1.4 compatible
- Upgraded clj-http and clj-oauth2 libs
- Fixed facebook API change in auth.clj
- Using uri.core to make uri
