### PR TITLE
upgrade to data.json 0.2.6

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,7 @@ pom.xml
 *jar
 lib
 classes
+target
+
+.lein*
+*.asc

--- a/project.clj
+++ b/project.clj
@@ -1,7 +1,8 @@
-(defproject clj-facebook-graph "0.4.0"
+(defproject clj-facebook-graph "0.4.1"
   :description "A Clojure client for the Facebook Graph API."
   :dependencies [[org.clojure/clojure "1.3.0"]
-                 [org.clojure/data.json "0.1.1"]
+                 ;; [org.clojure/data.json "0.1.1"]
+                 [org.clojure/data.json "0.2.6"]
                  [ring/ring-core "1.0.1"]
                  [clj-http "0.2.6"]
                  [clj-oauth2 "0.1.0"]]

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject yayitswei/clj-facebook-graph "0.4.1"
+(defproject yayitswei/clj-facebook-graph "0.4.2"
   :description "A Clojure client for the Facebook Graph API."
   :dependencies [[org.clojure/clojure "1.6.0"]
                  [org.clojure/data.json "0.2.6"]

--- a/project.clj
+++ b/project.clj
@@ -1,6 +1,6 @@
 (defproject yayitswei/clj-facebook-graph "0.4.1"
   :description "A Clojure client for the Facebook Graph API."
-  :dependencies [[org.clojure/clojure "1.3.0"]
+  :dependencies [[org.clojure/clojure "1.6.0"]
                  [org.clojure/data.json "0.2.6"]
                  [ring/ring-core "1.0.1"]
                  [clj-http "1.1.2"]

--- a/project.clj
+++ b/project.clj
@@ -4,7 +4,7 @@
                  ;; [org.clojure/data.json "0.1.1"]
                  [org.clojure/data.json "0.2.6"]
                  [ring/ring-core "1.0.1"]
-                 [clj-http "0.2.6"]
+                 [clj-http "1.1.2"]
                  [clj-oauth2 "0.1.0"]]
   :dev-dependencies [[ring/ring-devel "1.0.1"]
                      [ring/ring-jetty-adapter "1.0.0"]

--- a/project.clj
+++ b/project.clj
@@ -1,7 +1,6 @@
-(defproject clj-facebook-graph "0.4.1"
+(defproject yayitswei/clj-facebook-graph "0.4.1"
   :description "A Clojure client for the Facebook Graph API."
   :dependencies [[org.clojure/clojure "1.3.0"]
-                 ;; [org.clojure/data.json "0.1.1"]
                  [org.clojure/data.json "0.2.6"]
                  [ring/ring-core "1.0.1"]
                  [clj-http "1.1.2"]

--- a/src/clj_facebook_graph/auth.clj
+++ b/src/clj_facebook_graph/auth.clj
@@ -1,6 +1,6 @@
 (ns clj-facebook-graph.auth
-  (:use [clj-facebook-graph.helper :only [facebook-base-url facebook-fql-base-url]] 
-        [clojure.data.json :only [read-json]])
+  (:use [clj-facebook-graph.helper :only [facebook-base-url facebook-fql-base-url]]
+        [clojure.data.json :only [read-str]])
   (:require [clj-oauth2.client :as oauth2]
             [clojure.string :as str])
   (:import [org.apache.commons.codec.binary Base64]
@@ -83,7 +83,7 @@
     (let [[signiture payload] (str/split signed-request #"\.")
           signiture (str (strtr signiture "-_" "+/") "=")]
       (when (= signiture (hmac-sha-256 key payload))
-        (read-json (base64-decode payload))))))
+        (read-str (base64-decode payload))))))
 
 (defn extract-facebook-auth [session]
   (:facebook-auth (val session)))

--- a/src/clj_facebook_graph/client.clj
+++ b/src/clj_facebook_graph/client.clj
@@ -11,9 +11,9 @@
   (:use [clj-facebook-graph.helper :only [wrap-exceptions facebook-base-url facebook-fql-base-url]]
         [clj-facebook-graph.auth :only [wrap-facebook-access-token]]
         [clj-facebook-graph.error-handling :only [wrap-facebook-exceptions]]
-        [clojure.data.json :only [read-json]] 
         [clj-oauth2.client :only [wrap-oauth2]])
-  (:require [clj-http.client :as client]))
+  (:require [clj-http.client :as client]
+            [clojure.data.json]))
 
 (defn wrap-facebook-url-builder [client]
   "Offers some convenience by assemble a Facebook Graph API URL from a vector of keywords or strings.
@@ -23,7 +23,7 @@
   (here \"friends\"), you can also provide three or more
   keywords (or strings) like in the case of 'https://graph.facebook.com/me/videos/uploaded' for example."
   (fn [req]
-    (let [{:keys [url]} req]    
+    (let [{:keys [url]} req]
       (if (vector? url)
         (let [url-parts-as-str (map #(if (keyword? %) (name %) (str %)) url)
               url (apply str (interpose "/" (conj url-parts-as-str facebook-base-url)))]
@@ -41,7 +41,7 @@
                (or
                 (.startsWith content-type "text/javascript")
                 (.startsWith content-type "application/json")))
-        (assoc resp :body (read-json (:body resp)))
+        (assoc resp :body (clojure.data.json/read-str (:body resp)))
         resp))))
 
 (defn wrap-facebook-data-extractor [client]
@@ -105,8 +105,7 @@
          ))
   ([request] (wrap-request request client/wrap-request)))
 
-(def
-  request
+(def request
   (wrap-request #'clj-http.core/request))
 
 (defn get

--- a/src/clj_facebook_graph/client.clj
+++ b/src/clj_facebook_graph/client.clj
@@ -98,11 +98,9 @@
          wrap-request-fn
          wrap-oauth2
          wrap-facebook-access-token
-         wrap-json-response-conversion
          wrap-facebook-url-builder
          wrap-facebook-data-extractor
-         wrap-fql
-         ))
+         wrap-fql))
   ([request] (wrap-request request client/wrap-request)))
 
 (def request
@@ -111,7 +109,7 @@
 (defn get
   "Like #'request, but sets the :method and :url as appropriate."
   [url & [req]]
-  (request (merge req {:method :get :url url})))
+  (request (merge req {:method :get :url url :as :json})))
 
 (defn post
   "Like #'request, but sets the :method and :url as appropriate."

--- a/src/clj_facebook_graph/client.clj
+++ b/src/clj_facebook_graph/client.clj
@@ -13,7 +13,8 @@
         [clj-facebook-graph.error-handling :only [wrap-facebook-exceptions]]
         [clj-oauth2.client :only [wrap-oauth2]])
   (:require [clj-http.client :as client]
-            [clojure.data.json]))
+            [clojure.data.json])
+  (:refer-clojure :exclude [get]))
 
 (defn wrap-facebook-url-builder [client]
   "Offers some convenience by assemble a Facebook Graph API URL from a vector of keywords or strings.

--- a/src/clj_facebook_graph/error_handling.clj
+++ b/src/clj_facebook_graph/error_handling.clj
@@ -7,7 +7,7 @@
 ; You must not remove this notice, or any other, from this software.
 
 (ns clj-facebook-graph.error-handling
-  (:use [clojure.data.json])
+  (:require [clojure.data.json])
   (:import clj_facebook_graph.FacebookGraphException))
 
 (def
@@ -47,6 +47,7 @@
       (if (or (not (clojure.core/get req :throw-exceptions true))
               (not= status 400))
         resp
-        (throw (let [resp (assoc resp :body (read-json (:body resp)))]
+        (throw (let [resp (assoc resp :body
+                                 (clojure.data.json/read
+                                  (clojure.java.io/reader (:body resp))))]
                  (FacebookGraphException. (identify-facebook-error resp))))))))
-

--- a/src/clj_facebook_graph/helper.clj
+++ b/src/clj_facebook_graph/helper.clj
@@ -8,8 +8,7 @@
 
 (ns clj-facebook-graph.helper
   "Some helper functions."
-  (:use [clojure.data.json :only [read-json read-json-from Read-JSON-From]]
-        [clojure.java.io :only [reader]]
+  (:use [clojure.java.io :only [reader]]
         [clj-http.client :only [unexceptional-status?]]
         [clj-oauth2.uri :only [make-uri]]
         [clojure.string :only [blank?]]
@@ -20,13 +19,6 @@
 (def facebook-base-url "https://graph.facebook.com")
 
 (def facebook-fql-base-url "https://api.facebook.com/method/fql.query")
-
-(extend-type (Class/forName "[B")
-  Read-JSON-From
-  (read-json-from [input keywordize? eof-error? eof-value]
-    (read-json-from (PushbackReader. (InputStreamReader.
-                                      (ByteArrayInputStream. input)))
-                    keywordize? eof-error? eof-value)))
 
 (defn build-url [request]
   "Builds a URL string which corresponds to the information of the request."


### PR DESCRIPTION
The api for data.json has changed, so clj-facebook-graph is incompatible with most projects these days unless we upgrade.
